### PR TITLE
fix(ci): use uvx for ruff in publish workflow

### DIFF
--- a/.github/workflows/publish-easyremote.yml
+++ b/.github/workflows/publish-easyremote.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv sync --frozen
 
       - name: Lint
-        run: uv run ruff check easyremote tests gallery examples --output-format=full
+        run: uvx ruff check easyremote tests gallery examples --output-format=full
 
       - name: Test
         run: uv run pytest -q

--- a/tests/test_github_publish_workflow_contract.py
+++ b/tests/test_github_publish_workflow_contract.py
@@ -28,6 +28,7 @@ def test_publish_workflow_uses_uv_quality_gate() -> None:
     content = workflow.read_text(encoding="utf-8")
 
     assert "uv sync --frozen" in content
+    assert "uvx ruff check" in content
     assert "uv run pytest -q" in content
     assert "uv build" in content
     assert "uvx --from twine twine check dist/*" in content


### PR DESCRIPTION
- Switch publish workflow lint step from  to
- Avoid dependency on ruff being present in project environment
- Update workflow contract test accordingly